### PR TITLE
Update runners, formatting, and lto

### DIFF
--- a/.github/workflows/nightly-flatpak.yml
+++ b/.github/workflows/nightly-flatpak.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build on Linux
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 
@@ -26,18 +26,24 @@ jobs:
     - name: Setup Environment
       run: |
         sudo apt-get update
-        sudo apt-get install -y autoconf automake autopoint appstream build-essential cmake git libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev libogg-dev libopus-dev libsamplerate-dev libspeex-dev -y 
-        sudo apt-get install -y libtheora-dev libtool libtool-bin libturbojpeg0-dev libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make meson nasm ninja-build patch pkg-config tar zlib1g-dev
-        sudo apt-get install -y libva-dev libdrm-dev intltool libglib2.0-dev libunwind-dev libgtk-4-dev libgudev-1.0-dev libwebkit2gtk-4.0-dev libssl-dev
-        sudo pip3 install meson
+        sudo apt-get install -y \
+            autoconf automake autopoint appstream build-essential cmake git libass-dev \
+            libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev \
+            libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev libogg-dev libopus-dev \
+            libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libturbojpeg0-dev \
+            libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make meson nasm ninja-build \
+            patch pkg-config tar zlib1g-dev libva-dev libdrm-dev intltool libglib2.0-dev \
+            libunwind-dev libgtk-4-dev libgudev-1.0-dev libwebkit2gtk-4.1-dev libssl-dev \
+            python3-mesonpy
         sudo apt-get install flatpak flatpak-builder
         sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install -y flathub org.freedesktop.Sdk//23.08
-        sudo flatpak install -y flathub org.freedesktop.Platform//23.08
-        sudo flatpak install -y flathub org.gnome.Platform//46
-        sudo flatpak install -y flathub org.gnome.Sdk//46
-        sudo flatpak install -y org.freedesktop.Sdk.Extension.llvm16//23.08
-        sudo flatpak install -y org.freedesktop.Sdk.Extension.rust-stable//23.08
+        sudo flatpak install -y flathub \
+            org.freedesktop.Sdk//23.08 \
+            org.freedesktop.Platform//23.08 \
+            org.gnome.Platform//46 \
+            org.gnome.Sdk//46 \
+            org.freedesktop.Sdk.Extension.llvm16//23.08 \
+            org.freedesktop.Sdk.Extension.rust-stable//23.08
         sudo apt-get upgrade -y
 
     - name: Setup Cargo-C Toolchain
@@ -53,9 +59,9 @@ jobs:
     - name: Build HandBrake
       run: |
         cd HandBrake
-        ./configure --launch-jobs=1 --flatpak --enable-qsv --enable-vce --enable-nvenc --enable-nvdec
+        ./configure --launch-jobs=0 --flatpak --enable-qsv --enable-vce --enable-nvenc --enable-nvdec
         cd build
-        nice make pkg.create.flatpak --jobs=1
+        make -j"$(nproc)" pkg.create.flatpak
 
     - name: Upload Assets
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Build HandBrake
       run: |
         cd HandBrake
-        ./configure
+        ./configure --lto=on
         cd build
         make ub && make pkg.create
 

--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   build:
     name: Build on macOS
-    runs-on: macos-14
+    runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_15.3.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/nightly-ubuntu.yml
+++ b/.github/workflows/nightly-ubuntu.yml
@@ -48,7 +48,7 @@ jobs:
     - name: Build HandBrake Linux
       run: |
         cd HandBrake
-        ./configure --enable-qsv --enable-vce --enable-nvenc --enable-nvdec --launch-jobs=0 --launch
+        ./configure --lto=on --enable-qsv --enable-vce --enable-nvenc --enable-nvdec --launch-jobs=0 --launch
         mv build/HandBrakeCLI ../HandBrakeCLI-$(date +'%Y%m%d')-master-x86_64
         mv build/gtk/src/ghb ../ghb-$(date +'%Y%m%d')-master-x86_64
 

--- a/.github/workflows/nightly-ubuntu.yml
+++ b/.github/workflows/nightly-ubuntu.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build on Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
 
@@ -26,11 +26,14 @@ jobs:
     - name: Setup Environment
       run: |
         sudo apt-get update
-        sudo apt-get install autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev libturbojpeg0-dev libssl-dev
-        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev make nasm ninja-build patch tar zlib1g-dev appstream
-        sudo pip3 install meson
-        sudo apt-get install gettext libglib2.0-dev libgtk-4-dev
-        sudo apt-get install libva-dev libdrm-dev llvm clang
+        sudo apt-get install \
+            autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev \
+            libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev \
+            libmp3lame-dev libnuma-dev libturbojpeg0-dev libssl-dev libogg-dev libopus-dev \
+            libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev \
+            libx264-dev libxml2-dev libvpx-dev make nasm ninja-build patch tar zlib1g-dev \
+            appstream gettext libglib2.0-dev libgtk-4-dev python3-mesonpy libva-dev \
+            libdrm-dev
 
     - name: Setup Cargo-C Toolchain
       if: steps.linux-cargo-c-toolchain.outputs.cache-hit != 'true'
@@ -44,10 +47,10 @@ jobs:
 
     - name: Build HandBrake Linux
       run: |
-         cd HandBrake
-         ./configure --enable-qsv --enable-vce --enable-nvenc --enable-nvdec --launch-jobs=0 --launch
-         mv build/HandBrakeCLI ../HandBrakeCLI-$(date +'%Y%m%d')-master-x86_64
-         mv build/gtk/src/ghb ../ghb-$(date +'%Y%m%d')-master-x86_64
+        cd HandBrake
+        ./configure --enable-qsv --enable-vce --enable-nvenc --enable-nvdec --launch-jobs=0 --launch
+        mv build/HandBrakeCLI ../HandBrakeCLI-$(date +'%Y%m%d')-master-x86_64
+        mv build/gtk/src/ghb ../ghb-$(date +'%Y%m%d')-master-x86_64
 
     - name: Upload HandBrake CLI
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-win.yml
+++ b/.github/workflows/nightly-win.yml
@@ -5,7 +5,12 @@ on:
   schedule:
     - cron:  '30 7 * * 1,5'
   workflow_dispatch: 
-  
+
+env:
+  TOOLCHAIN_VERSION: "20241001"
+  TOOLCHAIN_SHA: "65450e9a10ece0b6c6fae37092982accde3774be"
+  TOOLCHAIN_FILE: "llvm-mingw-20241001-msvcrt-ubuntu-20.04-x86_64.tar.xz"
+
 jobs:
   build_mingw_arm:
     name: CLI / LibHB (ARM)
@@ -20,25 +25,24 @@ jobs:
         
     - name: Setup Toolchain
       run: |
-        wget https://github.com/mstorsjo/llvm-mingw/releases/download/20240917/llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz
-        SHA=$(sha1sum llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz)
-        EXPECTED="376abe9b34b5df9daab4769b3fa387999e452751  llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz"
-        if [ "$SHA" == "$EXPECTED" ];
-        then
+        wget https://github.com/mstorsjo/llvm-mingw/releases/download/${{ env.TOOLCHAIN_VERSION }}/${{ env.TOOLCHAIN_FILE }}
+        SHA=$(sha1sum ${{ env.TOOLCHAIN_FILE }})
+        EXPECTED="${{ env.TOOLCHAIN_SHA }}  ${{ env.TOOLCHAIN_FILE }}"
+        if [ "$SHA" == "$EXPECTED" ]; then
             echo "Toolchain Verified. Extracting ..."
             mkdir toolchains
-            mv llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz toolchains
+            mv ${{ env.TOOLCHAIN_FILE }} toolchains
             cd toolchains
-            tar xvf llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz
+            tar xvf ${{ env.TOOLCHAIN_FILE }}
         else
             echo "Toolchain Verification FAILED. Exiting!"
-            return -1
+            exit 1
         fi
-        
+
     - name: Build CLI and LibHB
       run: |
         CWDIR=$(pwd)
-        export PATH="$CWDIR/toolchains/llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64/bin:${PATH}"
+        export PATH="$CWDIR/toolchains/llvm-mingw-${{ env.TOOLCHAIN_VERSION }}-msvcrt-ubuntu-20.04-x86_64/bin:${PATH}"
         export PATH=/usr/bin:$PATH
         git clone https://github.com/HandBrake/HandBrake.git
         ./patch.sh
@@ -154,19 +158,18 @@ jobs:
 
     - name: Setup Toolchain
       run: |
-        wget https://github.com/mstorsjo/llvm-mingw/releases/download/20240917/llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz
-        SHA=$(sha1sum llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz)
-        EXPECTED="376abe9b34b5df9daab4769b3fa387999e452751  llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz"
-        if [ "$SHA" == "$EXPECTED" ];
-        then
+        wget https://github.com/mstorsjo/llvm-mingw/releases/download/${{ env.TOOLCHAIN_VERSION }}/${{ env.TOOLCHAIN_FILE }}
+        SHA=$(sha1sum ${{ env.TOOLCHAIN_FILE }})
+        EXPECTED="${{ env.TOOLCHAIN_SHA }}  ${{ env.TOOLCHAIN_FILE }}"
+        if [ "$SHA" == "$EXPECTED" ]; then
             echo "Toolchain Verified. Extracting ..."
             mkdir toolchains
-            mv llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz toolchains
+            mv ${{ env.TOOLCHAIN_FILE }} toolchains
             cd toolchains
-            tar xvf llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64.tar.xz
+            tar xvf ${{ env.TOOLCHAIN_FILE }}
         else
             echo "Toolchain Verification FAILED. Exiting!"
-            return -1
+            exit 1
         fi
 
     - name: Setup Cargo-C Toolchain
@@ -177,7 +180,7 @@ jobs:
     - name: Build CLI and LibHB
       run: |
         CWDIR=$(pwd)
-        export PATH="$CWDIR/toolchains/llvm-mingw-20240917-msvcrt-ubuntu-20.04-x86_64/bin:${PATH}"
+        export PATH="$CWDIR/toolchains/llvm-mingw-${{ env.TOOLCHAIN_VERSION }}-msvcrt-ubuntu-20.04-x86_64/bin:${PATH}"
         export PATH=/usr/bin:$PATH
         git clone https://github.com/HandBrake/HandBrake.git
         ./patch.sh

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,7 +19,7 @@ source=("HandBrake::git+https://github.com/HandBrake/HandBrake.git" "HandBrake-S
 _commondeps=(libxml2 libass libvorbis opus speex libtheora lame libjpeg-turbo
              x264 libx264.so jansson libvpx libva numactl)
 _guideps=(gst-plugins-base gtk4 libgudev)
-makedepends=(git intltool python nasm wget cmake meson llvm clang cargo-c
+makedepends=(git intltool python nasm wget cmake meson cargo-c base-devel
              "${_commondeps[@]}" "${_guideps[@]}")
 optdepends=('libdvdcss: for decoding encrypted DVDs'
             'intel-media-sdk: for enabling Intel QSV'
@@ -34,15 +34,16 @@ pkgver() {
   git describe --long | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
- build() {
+build() {
   ./HandBrake-SVT-AV1-PSY/patch.sh
   cd "HandBrake"
 
   ./configure \
     --prefix=/usr \
+    --lto=on \
     --enable-qsv \
-	--launch-jobs=$(nproc) \
-  	--launch
+    --launch-jobs=0 \
+    --launch
     #--harden \
     #--enable-x265 \
     #--enable-libdovi \
@@ -76,4 +77,3 @@ package_handbrake-svt-av1-psy-cli-git() {
   cd "$srcdir/HandBrake/build"
   install -D HandBrakeCLI "$pkgdir/usr/bin/HandBrakeCLI"
 }
-


### PR DESCRIPTION
`ubuntu-latest` is using Ubuntu 22.04 instead of Ubuntu 24.04 for some reason
Enabled LTO for macOS, Ubuntu, and Arch Linux
LTO doesn't work with Clang, so we're using GCC (except on Mac it just works for some reason)
Arch Linux was never even using Clang in the first place because it wasn't explicitly set
I couldn't get LTO to work for Windows and Flatpak
For Windows, I tried using GCC 14.2.0, and it [fails](https://github.com/Uranite/HandBrake-SVT-AV1-PSY/actions/runs/11146022269/job/30976969112) for some reason (ignore arm I don't think there is a GCC toolchain for it)
Flatpak just seems to ignore `--lto=on`
I also tried to make Flatpak use Clang, but it just won't use Clang for some reason