### PR TITLE
Update dependencies, fix warning, and try to optimize arch build

### DIFF
--- a/.github/workflows/nightly-arch.yml
+++ b/.github/workflows/nightly-arch.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Build HandBrake Arch Linux
       id: makepkg
-      uses: edlanglois/pkgbuild-action@v1
+      uses: edlanglois/pkgbuild-action@v1.1.9
 
     - name: Upload HandBrake-SVT-AV1-PSY Archive
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-flatpak.yml
+++ b/.github/workflows/nightly-flatpak.yml
@@ -33,8 +33,7 @@ jobs:
             libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libturbojpeg0-dev \
             libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make meson nasm ninja-build \
             patch pkg-config tar zlib1g-dev libva-dev libdrm-dev intltool libglib2.0-dev \
-            libunwind-dev libgtk-4-dev libgudev-1.0-dev libwebkit2gtk-4.1-dev libssl-dev \
-            python3-mesonpy
+            libunwind-dev libgtk-4-dev libgudev-1.0-dev libssl-dev python3-mesonpy
         sudo apt-get install flatpak flatpak-builder
         sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
         sudo flatpak install -y flathub \
@@ -61,7 +60,7 @@ jobs:
         cd HandBrake
         ./configure --launch-jobs=0 --flatpak --enable-qsv --enable-vce --enable-nvenc --enable-nvdec
         cd build
-        make -j"$(nproc)" pkg.create.flatpak
+        make pkg.create.flatpak --jobs=$(nproc)
 
     - name: Upload Assets
       uses: actions/upload-artifact@v4

--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -11,12 +11,12 @@ jobs:
     name: Build on macOS
     runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12.3'
+        python-version: '3.13.1'
 
     - name: Toolchain Cache
       id: mac-toolchain

--- a/.github/workflows/nightly-ubuntu.yml
+++ b/.github/workflows/nightly-ubuntu.yml
@@ -26,6 +26,7 @@ jobs:
     - name: Setup Environment
       run: |
         sudo apt-get update
+        sudo apt-get upgrade
         sudo apt-get install \
             autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev \
             libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev \

--- a/.github/workflows/nightly-win.yml
+++ b/.github/workflows/nightly-win.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch: 
 
 env:
-  TOOLCHAIN_VERSION: "20241001"
-  TOOLCHAIN_SHA: "65450e9a10ece0b6c6fae37092982accde3774be"
-  TOOLCHAIN_FILE: "llvm-mingw-20241001-msvcrt-ubuntu-20.04-x86_64.tar.xz"
+  TOOLCHAIN_VERSION: "20241217"
+  TOOLCHAIN_SHA: "60fb5b469adb58592d67fa3b689727081e40712a"
+  TOOLCHAIN_FILE: "llvm-mingw-20241217-msvcrt-ubuntu-20.04-x86_64.tar.xz"
 
 jobs:
   build_mingw_arm:
@@ -20,7 +20,8 @@ jobs:
 
     - name: Setup Environment
       run: |
-        sudo apt-get purge cmake -y
+        sudo apt-get update
+        sudo apt-get upgrade
         sudo apt-get install automake autoconf build-essential intltool libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax cmake python3-mesonpy
         
     - name: Setup Toolchain
@@ -28,6 +29,8 @@ jobs:
         wget https://github.com/mstorsjo/llvm-mingw/releases/download/${{ env.TOOLCHAIN_VERSION }}/${{ env.TOOLCHAIN_FILE }}
         SHA=$(sha1sum ${{ env.TOOLCHAIN_FILE }})
         EXPECTED="${{ env.TOOLCHAIN_SHA }}  ${{ env.TOOLCHAIN_FILE }}"
+        echo "Calculated SHA: $SHA"
+        echo "Expected SHA:  $EXPECTED"
         if [ "$SHA" == "$EXPECTED" ]; then
             echo "Toolchain Verified. Extracting ..."
             mkdir toolchains
@@ -152,7 +155,8 @@ jobs:
 
     - name: Setup Environment
       run: |
-        sudo apt-get purge cmake -y
+        sudo apt-get update
+        sudo apt-get upgrade
         sudo apt-get install automake autoconf build-essential intltool libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax cmake python3-mesonpy
         rustup target add x86_64-pc-windows-gnu
 
@@ -161,6 +165,8 @@ jobs:
         wget https://github.com/mstorsjo/llvm-mingw/releases/download/${{ env.TOOLCHAIN_VERSION }}/${{ env.TOOLCHAIN_FILE }}
         SHA=$(sha1sum ${{ env.TOOLCHAIN_FILE }})
         EXPECTED="${{ env.TOOLCHAIN_SHA }}  ${{ env.TOOLCHAIN_FILE }}"
+        echo "Calculated SHA: $SHA"
+        echo "Expected SHA:  $EXPECTED"
         if [ "$SHA" == "$EXPECTED" ]; then
             echo "Toolchain Verified. Extracting ..."
             mkdir toolchains

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,79 +1,152 @@
-# Maintainer: Fabio 'Lolix' Loli <fabio.loli@disroot.org> -> https://github.com/FabioLolix
-# Contributor: HurricanePootis <hurricanepootis@protonmail.com>
-# Contributor: graysky <graysky AT archlinux DOT us>
-# Contributor: jiribb <jiribb@gmail.com>
-# Contributor: David Spicer <azleifel at googlemail dot com>
-# Contributor: Andrew Brouwers
-# Contributor: ponsfoot <cabezon dot hashimoto at gmail dot com>
-# Contributor: Stefan Husmann <stefan-husmann@t-online.de>
+# Maintainer: Holger Obermaier <holgerob@gmx.de>
+# Contributor: Evangelos Foutras <evangelos@foutrelis.com>
+# Contributor: Giovanni Scafora <giovanni@archlinux.org>
+# Contributor: Sebastien Piccand <sebcactus gmail com>
 
-pkgbase=handbrake-svt-av1-psy-git
-pkgname=(handbrake-svt-av1-psy-git handbrake-svt-av1-psy-cli-git)
-pkgver=1.8.0.r135.gdeb4c4578
-pkgrel=1
-pkgdesc="Multithreaded video transcoder. Enabled: x265, nvenc, fdk-aac, qsv, vce, numa, hardened. Last stable branch"
-arch=(i686 x86_64)
-url="https://handbrake.fr/"
-license=(GPL-2.0-only)
-source=("HandBrake::git+https://github.com/HandBrake/HandBrake.git" "HandBrake-SVT-AV1-PSY::git+https://github.com/Nj0be/HandBrake-SVT-AV1-PSY.git")
-_commondeps=(libxml2 libass libvorbis opus speex libtheora lame libjpeg-turbo
-             x264 libx264.so jansson libvpx libva numactl)
-_guideps=(gst-plugins-base gtk4 libgudev)
-makedepends=(git intltool python nasm wget cmake meson cargo-c base-devel
-             "${_commondeps[@]}" "${_guideps[@]}")
-optdepends=('libdvdcss: for decoding encrypted DVDs'
-            'intel-media-sdk: for enabling Intel QSV'
-            'nvidia-utils: for Nvidia users, enable Nvidia nvenc'
-            'cuda: for Nvidia users, enable Nvidia nvdec'
-            'amf-amdgpu-pro: for enabling AMD AMF')
-sha256sums=('SKIP' 'SKIP')
-options=(!lto)
+pkgname=(
+  'handbrake-svt-av1-psy-llvm-optimized'
+  'handbrake-svt-av1-psy-llvm-optimized-cli'
+)
 
 pkgver() {
-  cd "HandBrake"
-  git describe --long | sed 's/^v//;s/\([^-]*-g\)/r\1/;s/-/./g'
+  git -C HandBrake/ gc --auto --prune=now
+  git -C HandBrake/ describe ${_commit} | sed -e 's/^v//g' -e 's/-/.r/' -e 's/-/./'
+}
+
+pkgver=1.9.0
+pkgrel=2
+arch=('x86_64')
+url="https://handbrake.fr/"
+license=(GPL-2.0-only)
+_commondeps=(
+  'bzip2'
+  'fribidi'
+  'gcc-libs'
+  'jansson'
+  'lame'
+  'libass'
+  'libjpeg-turbo'
+  'libogg'
+  'libtheora'
+  'libva'
+  'libvorbis'
+  'libvpx'
+  'libxml2'
+  'numactl'
+  'opus'
+  'speex'
+  'x264'
+  'xz'
+  'zlib'
+)
+_guideps=(
+  'at-spi2-core'
+  'cairo'
+  'fontconfig'
+  'freetype2'
+  'gdk-pixbuf2'
+  'glib2'
+  'gst-plugins-base'
+  'gst-plugins-base-libs'
+  'gstreamer'
+  'gtk4'
+  'harfbuzz'
+  'libgudev'
+  'pango'
+)
+makedepends=(
+  'base-devel'
+  'intltool'
+  'python'
+  'nasm'
+  'wget'
+  'cmake'
+  'meson'
+  'git'
+  'clang'
+  'lld'
+  'llvm'
+  # AMD VCE encoding on Linux requires Vulkan
+  'vulkan-headers'
+  "${_commondeps[@]}"
+  "${_guideps[@]}"
+)
+options=('!lto') # https://bugs.archlinux.org/task/72600
+source=("HandBrake::git+https://github.com/HandBrake/HandBrake.git" "HandBrake-SVT-AV1-PSY::git+https://github.com/Nj0be/HandBrake-SVT-AV1-PSY.git")
+sha256sums=('SKIP' 'SKIP')
+
+setup_compiler() {
+  export CC="/usr/bin/clang"
+  unset CFLAGS
+  export CXX="/usr/bin/clang++"
+  unset CXXFLAGS
+  export CPP="/usr/bin/clang-cpp"
+  export LD="/usr/bin/lld"
+  export LDFLAGS="-fuse-ld=lld"
+  export AR="/usr/bin/llvm-ar"
+  export RANLIB="/usr/bin/llvm-ranlib"
+  export NM="/usr/bin/llvm-nm"
+  export ADDR2LINE="/usr/bin/llvm-addr2line"
+  export OBJCOPY="/usr/bin/llvm-objcopy"
+  export OBJDUMP="/usr/bin/llvm-objdump"
+  export READELF="/usr/bin/llvm-readelf"
+  export STRIP="/usr/bin/llvm-strip"
 }
 
 build() {
   ./HandBrake-SVT-AV1-PSY/patch.sh
-  cd "HandBrake"
+  setup_compiler
 
-  ./configure \
-    --prefix=/usr \
-    --lto=on \
-    --enable-qsv \
-    --launch-jobs=0 \
-    --launch
-    #--harden \
-    #--enable-x265 \
-    #--enable-libdovi \
-    #--enable-numa \
-    #--enable-fdk-aac \
-    #--enable-nvdec \
-    #--enable-nvenc \
-    #--enable-vce
+  local -a CONFIGURE_OPTIONS=(
+    --launch-jobs=0
+    --prefix=/usr
+    --cc="${CC}"
+    --ar="${AR}"
+    --ranlib="${RANLIB}"
+    --strip="${STRIP}"
+    --lto=on
+    --enable-qsv
+    --enable-vce
+  )
+
+  cd "${srcdir}/HandBrake" || exit
+  ./configure "${CONFIGURE_OPTIONS[@]}"
+  make -C build
 }
 
-package_handbrake-svt-av1-psy-git() {
-  pkgdesc="Multithreaded video transcoder"
-  depends=("${_commondeps[@]}" "${_guideps[@]}")
-  optdepends+=('gst-plugins-good: for video previews'
-               'gst-libav: for video previews')
+package_handbrake-svt-av1-psy-llvm-optimized() {
+  pkgdesc="Multithreaded video transcoder optimized with LLVM"
+  depends=(
+    'desktop-file-utils'
+    'hicolor-icon-theme'
+    "${_commondeps[@]}"
+    "${_guideps[@]}"
+  )
+  optdepends=(
+    'gst-plugins-good: for video previews'
+    'gst-libav: for video previews'
+    'intel-media-sdk: Intel QuickSync support'
+    'libdvdcss: for decoding encrypted DVDs'
+  )
   provides=(handbrake)
   conflicts=(handbrake)
 
-  cd "$srcdir/HandBrake/build"
-
-  make DESTDIR="$pkgdir" install
-  rm "$pkgdir/usr/bin/HandBrakeCLI"
+  make \
+    --directory="${srcdir}/HandBrake/build" \
+    DESTDIR="${pkgdir}" \
+    install
+  rm "${pkgdir}/usr/bin/HandBrakeCLI"
 }
 
-package_handbrake-svt-av1-psy-cli-git() {
-  pkgdesc="Multithreaded video transcoder (CLI)"
+package_handbrake-svt-av1-psy-llvm-optimized-cli() {
+  pkgdesc="Multithreaded video transcoder optimized with LLVM (CLI)"
   depends=("${_commondeps[@]}")
+  optdepends=(
+    'intel-media-sdk: Intel QuickSync support'
+    'libdvdcss: for decoding encrypted DVDs'
+  )
   provides=(handbrake-cli)
   conflicts=(handbrake-cli)
 
-  cd "$srcdir/HandBrake/build"
-  install -D HandBrakeCLI "$pkgdir/usr/bin/HandBrakeCLI"
+  install -D "${srcdir}/HandBrake/build/HandBrakeCLI" "${pkgdir}/usr/bin/HandBrakeCLI"
 }


### PR DESCRIPTION
Update mac, ubuntu, and windows dependencies
Remove unnecessary libwebkit2gtk-4.1-dev in flatpak
Fix set-output warning in arch build
Use modified handbrake-llvm-optimized from AUR for potentially faster build

If you're using arch or arch based distro, can you pls test and see if its faster?