### PR TITLE
Fix build failing and other

### DIFF
--- a/.github/workflows/nightly-flatpak.yml
+++ b/.github/workflows/nightly-flatpak.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build on Linux
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -9,9 +9,9 @@ on:
 jobs:
   build:
     name: Build on macOS
-    runs-on: macos-15
+    runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.2.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/nightly-ubuntu.yml
+++ b/.github/workflows/nightly-ubuntu.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build on Ubuntu
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 
@@ -26,7 +26,6 @@ jobs:
     - name: Setup Environment
       run: |
         sudo apt-get update
-        sudo apt-get upgrade
         sudo apt-get install \
             autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev \
             libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev \

--- a/.github/workflows/nightly-win.yml
+++ b/.github/workflows/nightly-win.yml
@@ -3,8 +3,8 @@ name: Windows Build
 on:
   pull_request:
   schedule:
-    - cron:  '30 7 * * 1,5'
-  workflow_dispatch: 
+    - cron: '30 7 * * 1,5'
+  workflow_dispatch:
 
 env:
   TOOLCHAIN_VERSION: "20241217"
@@ -21,7 +21,6 @@ jobs:
     - name: Setup Environment
       run: |
         sudo apt-get update
-        sudo apt-get upgrade
         sudo apt-get install automake autoconf build-essential intltool libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax cmake python3-mesonpy
         
     - name: Setup Toolchain
@@ -156,7 +155,6 @@ jobs:
     - name: Setup Environment
       run: |
         sudo apt-get update
-        sudo apt-get upgrade
         sudo apt-get install automake autoconf build-essential intltool libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax cmake python3-mesonpy
         rustup target add x86_64-pc-windows-gnu
 
@@ -333,7 +331,7 @@ jobs:
           sed -e 's/^/| /'  -i sha256.txt
           sed -e 's/$/ |/' -i sha256.txt
           cat sha256.txt >> win_rel_body.md
-      
+
       # Publishing the Release
       - name: Remove the old Release
         uses: dev-drprasad/delete-older-releases@v0.3.4
@@ -342,7 +340,7 @@ jobs:
           delete_tag_pattern: "win"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          
+
       - uses: ncipollo/release-action@v1
         with:
           artifacts: "win/*.*"

--- a/.github/workflows/nightly-win.yml
+++ b/.github/workflows/nightly-win.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
 
 env:
-  TOOLCHAIN_VERSION: "20241217"
-  TOOLCHAIN_SHA: "60fb5b469adb58592d67fa3b689727081e40712a"
-  TOOLCHAIN_FILE: "llvm-mingw-20241217-msvcrt-ubuntu-20.04-x86_64.tar.xz"
+  TOOLCHAIN_VERSION: "20250114"
+  TOOLCHAIN_SHA: "7db6b9c2944b0f0cc2f71e2a415873709e027f9b"
+  TOOLCHAIN_FILE: "llvm-mingw-20250114-msvcrt-ubuntu-20.04-x86_64.tar.xz"
 
 jobs:
   build_mingw_arm:

--- a/patches/0003-add-tunes.patch
+++ b/patches/0003-add-tunes.patch
@@ -1,13 +1,8 @@
 diff --git a/libhb/encsvtav1.c b/libhb/encsvtav1.c
-index a2f18034f..e525efb07 100644
+index 2f16984d5..f7913036d 100644
 --- a/libhb/encsvtav1.c
 +++ b/libhb/encsvtav1.c
-@@ -184,10 +184,19 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
-         }
-     }
- 
-+
-     if (job->encoder_tune != NULL && strstr("ssim", job->encoder_tune) != NULL)
+@@ -188,6 +188,14 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
      {
          param->tune = 2;
      }
@@ -24,15 +19,15 @@ index a2f18034f..e525efb07 100644
          param->tune = 1;
 
 diff --git a/libhb/handbrake/av1_common.h b/libhb/handbrake/av1_common.h
-index 79d19c1f0..713ab04b0 100644
+index 6d53a9dac..31158f6d0 100644
 --- a/libhb/handbrake/av1_common.h
 +++ b/libhb/handbrake/av1_common.h
-@@ -31,7 +31,7 @@ static const char * const av1_svt_preset_names[] =
+@@ -31,7 +31,7 @@ static const char * const hb_av1_svt_preset_names[] =
  
- static const char * const av1_svt_tune_names[] =
+ static const char * const hb_av1_svt_tune_names[] =
  {
--    "psnr", "ssim", "fastdecode", NULL
-+    "psnr", "ssim", "subjective ssim", "still picture", "fastdecode", NULL
+-    "vq", "psnr", "ssim", "fastdecode", NULL
++    "vq", "psnr", "ssim", "subjective ssim", "still picture", "fastdecode", NULL
  };
  
- static const char * const av1_svt_profile_names[] =
+ static const char * const hb_av1_svt_profile_names[] =

--- a/patches/0005-add-presets.patch
+++ b/patches/0005-add-presets.patch
@@ -1,13 +1,13 @@
 diff --git a/libhb/handbrake/av1_common.h b/libhb/handbrake/av1_common.h
-index 79d19c1f0..245e36c10 100644
+index 6d53a9dac..0d6abb3fd 100644
 --- a/libhb/handbrake/av1_common.h
 +++ b/libhb/handbrake/av1_common.h
 @@ -26,7 +26,7 @@ static const int          hb_av1_level_values[] = {
  
- static const char * const av1_svt_preset_names[] =
+ static const char * const hb_av1_svt_preset_names[] =
  {
 -    "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "0", "-1", NULL
 +    "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "0", "-1", "-2", "-3", NULL
  };
  
- static const char * const av1_svt_tune_names[] =
+ static const char * const hb_av1_svt_tune_names[] =


### PR DESCRIPTION
Fix the patches causing build to fail
Update Windows build toolchain to 20250114
`sudo apt-get upgrade` seems to be a waste of time without any benefit, so it's now removed for Ubuntu and Windows

Reduce future maintenance burden:
- Rename `ubuntu-24.04` to `ubuntu-latest` since Ubuntu 24.04 is now the latest
- Reverted MacOS version to default and the Xcode version to also default

Also, sorry that my previous changes just caused more future work.