### PR TITLE
Removed cpuinfo (fixes #16)

### DIFF
--- a/patches/0008-remove-cpuinfo.patch
+++ b/patches/0008-remove-cpuinfo.patch
@@ -1,0 +1,190 @@
+diff --git a/contrib/cpuinfo/module.defs b/contrib/cpuinfo/module.defs
+deleted file mode 100644
+index 616a7508f..000000000
+--- a/contrib/cpuinfo/module.defs
++++ /dev/null
+@@ -1,47 +0,0 @@
+-$(eval $(call import.MODULE.defs,CPUINFO,cpuinfo))
+-$(eval $(call import.CONTRIB.defs,CPUINFO))
+-
+-CPUINFO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/cpuinfo-b73ae6c.tar.gz
+-CPUINFO.FETCH.sha256  = 589c9241d361667ef9a2f2ee68846795949331f13ed7acc86f5d3cc4b856b6a8
+-
+-CPUINFO.build_dir             = build
+-CPUINFO.CONFIGURE.exe         = cmake
+-CPUINFO.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(CPUINFO.CONFIGURE.prefix)"
+-CPUINFO.CONFIGURE.deps        =
+-CPUINFO.CONFIGURE.static      =
+-CPUINFO.CONFIGURE.shared      = -DCPUINFO_LIBRARY_TYPE=static -DCPUINFO_BUILD_TOOLS=OFF -DCPUINFO_BUILD_UNIT_TESTS=OFF \
+-                                -DCPUINFO_BUILD_MOCK_TESTS=OFF -DCPUINFO_BUILD_BENCHMARKS=OFF
+-CPUINFO.CONFIGURE.extra       = -DCMAKE_INSTALL_LIBDIR=lib
+-
+-ifneq (none,$(CPUINFO.GCC.g))
+-    CPUINFO.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+-else
+-    CPUINFO.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+-endif
+-
+-ifeq (darwin,$(HOST.system))
+-    CPUINFO.CONFIGURE.extra += -DCMAKE_SYSTEM_PROCESSOR=$(HOST.machine)
+-    CPUINFO.CONFIGURE.extra += -DCMAKE_OSX_ARCHITECTURES=$(HOST.machine)
+-endif
+-
+-ifeq (1,$(HOST.cross))
+-    ifeq (mingw,$(HOST.system))
+-        CPUINFO.CONFIGURE.extra += -DWIN32=ON -DMINGW=ON
+-        CPUINFO.CONFIGURE.extra += -DCMAKE_SYSTEM_NAME=Windows
+-        CPUINFO.CONFIGURE.extra += -DCMAKE_SYSTEM_PROCESSOR=$(HOST.machine)
+-        CPUINFO.CONFIGURE.extra += -DCMAKE_C_COMPILER=$(CPUINFO.GCC.gcc)
+-        CPUINFO.CONFIGURE.extra += -DCMAKE_CXX_COMPILER=$(CPUINFO.GCC.gxx)
+-        CPUINFO.CONFIGURE.extra += -DCMAKE_RC_COMPILER=$(HOST.cross.prefix)windres
+-        CPUINFO.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(CPUINFO.CONFIGURE.host)"
+-    else ifeq ($(HOST.system),darwin)
+-        CPUINFO.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(CPUINFO.CONFIGURE.host)"
+-    else
+-        CPUINFO.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(CPUINFO.CONFIGURE.host)"
+-    endif
+-    CPUINFO.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(CPUINFO.CONFIGURE.build)"
+-else
+-    CPUINFO.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(CPUINFO.CONFIGURE.host)"
+-endif
+-
+-## find CMakeLists.txt
+-CPUINFO.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(CPUINFO.EXTRACT.dir/))"
+diff --git a/contrib/cpuinfo/module.rules b/contrib/cpuinfo/module.rules
+deleted file mode 100644
+index 5532fdfa9..000000000
+--- a/contrib/cpuinfo/module.rules
++++ /dev/null
+@@ -1,2 +0,0 @@
+-$(eval $(call import.MODULE.rules,CPUINFO))
+-$(eval $(call import.CONTRIB.rules,CPUINFO))
+diff --git a/contrib/svt-av1/module.defs b/contrib/svt-av1/module.defs
+index 0d400e08d..d72bab977 100644
+--- a/contrib/svt-av1/module.defs
++++ b/contrib/svt-av1/module.defs
+@@ -1,6 +1,4 @@
+-__deps__ := CPUINFO
+-
+-$(eval $(call import.MODULE.defs,SVT-AV1,svt-av1,$(__deps__)))
++$(eval $(call import.MODULE.defs,SVT-AV1,svt-av1))
+ $(eval $(call import.CONTRIB.defs,SVT-AV1))
+ 
+ SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v3.0.0.tar.gz
+diff --git a/gtk/meson.build b/gtk/meson.build
+index 350a97c4b..83233cea2 100644
+--- a/gtk/meson.build
++++ b/gtk/meson.build
+@@ -40,7 +40,6 @@ ghb_deps = [
+   dependency('libavformat'),
+   dependency('libavutil'),
+   dependency('libbluray'),
+-  dependency('libcpuinfo'),
+   dependency('libswresample'),
+   dependency('libswscale'),
+   dependency('libturbojpeg'),
+diff --git a/libhb/module.defs b/libhb/module.defs
+index 504a40f54..5fbb4750d 100644
+--- a/libhb/module.defs
++++ b/libhb/module.defs
+@@ -1,4 +1,4 @@
+-__deps__ := BZIP2 CPUINFO LIBVPX SVT-AV1 FFMPEG FREETYPE LAME LIBASS \
++__deps__ := BZIP2 LIBVPX SVT-AV1 FFMPEG FREETYPE LAME LIBASS \
+     LIBDVDREAD LIBDVDNAV LIBICONV LIBTHEORA LIBVORBIS LIBOGG \
+     X264 X265 ZLIB LIBBLURAY FDKAAC LIBVPL LIBGNURX JANSSON \
+     HARFBUZZ LIBOPUS LIBSPEEX LIBDAV1D LIBJPEGTURBO LIBDOVI
+@@ -116,7 +116,7 @@ LIBHB.dll = $(LIBHB.build/)hb.dll
+ LIBHB.lib = $(LIBHB.build/)hb.lib
+ 
+ LIBHB.dll.libs = $(foreach n, \
+-        ass avformat avfilter avcodec avutil swresample cpuinfo dvdnav dvdread \
++        ass avformat avfilter avcodec avutil swresample dvdnav dvdread \
+         freetype mp3lame swscale vpx theora vorbis vorbisenc ogg x264 \
+         bluray jansson harfbuzz opus speex dav1d turbojpeg zimg SvtAv1Enc, \
+         $(CONTRIB.build/)lib/lib$(n).a )
+diff --git a/macosx/HandBrake.xcodeproj/project.pbxproj b/macosx/HandBrake.xcodeproj/project.pbxproj
+index 90435b97e..c4aebca18 100644
+--- a/macosx/HandBrake.xcodeproj/project.pbxproj
++++ b/macosx/HandBrake.xcodeproj/project.pbxproj
+@@ -204,8 +204,6 @@
+ 		A93341EF243E15BE003A82C2 /* HandBrakeXPCService3.xpc in Copy Files */ = {isa = PBXBuildFile; fileRef = A93341D5243E158B003A82C2 /* HandBrakeXPCService3.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+ 		A93341F0243E15BE003A82C2 /* HandBrakeXPCService4.xpc in Copy Files */ = {isa = PBXBuildFile; fileRef = A93341E6243E158E003A82C2 /* HandBrakeXPCService4.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+ 		A93341F1243E15CE003A82C2 /* HandBrakeXPCService.xpc in Copy Files */ = {isa = PBXBuildFile; fileRef = A964D39522FDE8EE00DFCAEA /* HandBrakeXPCService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+-		A935B1662D68B68C00486A51 /* libcpuinfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A935B1652D68B67F00486A51 /* libcpuinfo.a */; };
+-		A935B1672D68B6D300486A51 /* libcpuinfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A935B1652D68B67F00486A51 /* libcpuinfo.a */; };
+ 		A939DD8B1FC8826A00135F2A /* HBPresetsMenuBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = A939DD8A1FC8826A00135F2A /* HBPresetsMenuBuilder.m */; };
+ 		A93CD3172C47CAFC00B11335 /* HBTitleSelectionRange.m in Sources */ = {isa = PBXBuildFile; fileRef = A93CD3162C47CAFC00B11335 /* HBTitleSelectionRange.m */; };
+ 		A93E0ED31972957000FD67FB /* HBVideoController.m in Sources */ = {isa = PBXBuildFile; fileRef = A93E0ED11972957000FD67FB /* HBVideoController.m */; };
+@@ -617,7 +615,6 @@
+ 		A93341C4243E1583003A82C2 /* HandBrakeXPCService2.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = HandBrakeXPCService2.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		A93341D5243E158B003A82C2 /* HandBrakeXPCService3.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = HandBrakeXPCService3.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		A93341E6243E158E003A82C2 /* HandBrakeXPCService4.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = HandBrakeXPCService4.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+-		A935B1652D68B67F00486A51 /* libcpuinfo.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcpuinfo.a; path = external/contrib/lib/libcpuinfo.a; sourceTree = BUILT_PRODUCTS_DIR; };
+ 		A939DD891FC8826A00135F2A /* HBPresetsMenuBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HBPresetsMenuBuilder.h; sourceTree = "<group>"; };
+ 		A939DD8A1FC8826A00135F2A /* HBPresetsMenuBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HBPresetsMenuBuilder.m; sourceTree = "<group>"; };
+ 		A93B0DF61C804CF50051A3FA /* NSDictionary+HBAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+HBAdditions.h"; sourceTree = "<group>"; };
+@@ -1277,7 +1274,6 @@
+ 				A9AB9AA821181CC700BB3C7E /* CoreVideo.framework in Frameworks */,
+ 				A9AB9AA621181CA900BB3C7E /* VideoToolbox.framework in Frameworks */,
+ 				A9ABD1A91E2A0F8200EC8B65 /* CoreGraphics.framework in Frameworks */,
+-				A935B1672D68B6D300486A51 /* libcpuinfo.a in Frameworks */,
+ 				A9ABD1A71E2A0F7500EC8B65 /* CoreText.framework in Frameworks */,
+ 				273F203014ADB9790021BE6D /* AudioToolbox.framework in Frameworks */,
+ 				273F203314ADB9F00021BE6D /* CoreServices.framework in Frameworks */,
+@@ -1381,7 +1377,6 @@
+ 				A91CE2D01C7DABCE0068F46F /* libbz2.tbd in Frameworks */,
+ 				1CBC683520BE014800A26CC2 /* liblzma.a in Frameworks */,
+ 				1C53DE8D20BD598D006BBCA8 /* libspeex.a in Frameworks */,
+-				A935B1662D68B68C00486A51 /* libcpuinfo.a in Frameworks */,
+ 				1C0695AF20BD193D001543DA /* libswresample.a in Frameworks */,
+ 				A900E6BD1D7B1B5A00CB6C0A /* libopus.a in Frameworks */,
+ 				A99E13392833B97A0006D720 /* libSvtAv1Enc.a in Frameworks */,
+@@ -1426,6 +1421,7 @@
+ 		271BA4C714B1236D00BC1D2C /* Static Libraries */ = {
+ 			isa = PBXGroup;
+ 			children = (
++				A9E34AD4297871FE00C5DD82 /* libdovi.a */,
+ 				1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */,
+ 				1C280BF320BD58DD00D5ECC2 /* libspeex.a */,
+ 				1CBC683320BE014800A26CC2 /* liblzma.a */,
+@@ -1454,7 +1450,6 @@
+ 				A9E165511C523016003EF30E /* libavfilter.a */,
+ 				1C15C82B1CD7722500368223 /* libharfbuzz.a */,
+ 				A9935867256C349B00A6875E /* libzimg.a */,
+-				A935B1652D68B67F00486A51 /* libcpuinfo.a */,
+ 				A99E13372833B97A0006D720 /* libSvtAv1Enc.a */,
+ 			);
+ 			name = "Static Libraries";
+@@ -1605,7 +1600,6 @@
+ 			isa = PBXGroup;
+ 			children = (
+ 				277EFE9217ED799E001D4A6A /* libfdk-aac.a */,
+-				A9E34AD4297871FE00C5DD82 /* libdovi.a */,
+ 				22CC9E74191EBEA500C69D81 /* libx265.a */,
+ 			);
+ 			name = "Static Libraries (optional)";
+diff --git a/make/include/main.defs b/make/include/main.defs
+index 530d3e0fa..e073a2259 100644
+--- a/make/include/main.defs
++++ b/make/include/main.defs
+@@ -49,7 +49,6 @@ ifeq (1,$(FEATURE.x265))
+ endif
+ 
+ MODULES += contrib/libdav1d
+-MODULES += contrib/cpuinfo
+ MODULES += contrib/svt-av1
+ MODULES += contrib/zimg
+ MODULES += contrib/ffmpeg
+diff --git a/test/module.defs b/test/module.defs
+index 5dcd06743..91c762e51 100644
+--- a/test/module.defs
++++ b/test/module.defs
+@@ -16,7 +16,7 @@ TEST.GCC.L = $(CONTRIB.build/)lib
+ 
+ TEST.libs = $(LIBHB.a)
+ 
+-TEST.pkgconfig_libs = libass libavformat libavfilter libavcodec libavutil libswresample libcpuinfo dvdnav \
++TEST.pkgconfig_libs = libass libavformat libavfilter libavcodec libavutil libswresample dvdnav \
+ 	dvdread libswscale theoraenc theoradec vorbis vorbisenc ogg x264 libbluray \
+ 	jansson libturbojpeg SvtAv1Enc
+ 


### PR DESCRIPTION
Removing cpuinfo dependency resolves the windows crash.