### PR TITLE
Create 0006-fix-uninitialized-memory.patch

### DIFF
--- a/patches/0006-fix-uninitialized-memory.patch
+++ b/patches/0006-fix-uninitialized-memory.patch
@@ -1,0 +1,17 @@
+diff --git a/Source/Lib/Codec/common_utils.h b/Source/Lib/Codec/common_utils.h
+index ea1106b2..f828bdfe 100644
+--- a/Source/Lib/Codec/common_utils.h
++++ b/Source/Lib/Codec/common_utils.h
+@@ -67,7 +67,11 @@ static INLINE PredictionMode get_uv_mode(UvPredictionMode mode) {
+ // CFL pred behaviorally maps to a unipred inter mode better than to DC intra mode,
+ // so manually account for that case
+ static INLINE PredictionMode get_uv_mode_cfl_aware(UvPredictionMode mode) {
+-    return mode != UV_CFL_PRED ? get_uv_mode(mode) : NEARESTMV;
++    if (mode >= UV_DC_PRED && mode < UV_INTRA_MODES) {
++        return mode != UV_CFL_PRED ? get_uv_mode(mode) : NEARESTMV;
++    } else {
++        return INTRA_INVALID;
++    }
+ }
+ 
+ static INLINE TxType intra_mode_to_tx_type(PredictionMode pred_mode, UvPredictionMode pred_mode_uv,


### PR DESCRIPTION
fix: Prevent crash from uninitialized memory in spy-rd logic https://github.com/BlueSwordM/svt-av1-psyex/pull/21