### PR TITLE
Fix build failure

### DIFF
--- a/.github/workflows/nightly-arch.yml
+++ b/.github/workflows/nightly-arch.yml
@@ -43,6 +43,7 @@ jobs:
     name: Deploy Nightly Build
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name != 'pull_request'
     steps:
     - uses: actions/checkout@v4
        

--- a/.github/workflows/nightly-flatpak.yml
+++ b/.github/workflows/nightly-flatpak.yml
@@ -73,6 +73,7 @@ jobs:
     name: Deploy Nightly Build
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
        

--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -74,6 +74,7 @@ jobs:
     name: Deploy Nightly Build
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
        

--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -33,7 +33,7 @@ jobs:
           ~/.cargo/bin/cargo-capi
           ~/.cargo/bin/cargo-cbuild
           ~/.cargo/bin/cargo-cinstall
-        key: ${{ runner.os }}-${{ runner.arch }}-cargo-c-toolchain
+        key: ${{ runner.os }}-${{ runner.arch }}-cargo-c-toolchain-1
 
     - name: Download the Source Code
       run: |

--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.13.1'
+        python-version: '3.13.7'
 
     - name: Toolchain Cache
       id: mac-toolchain

--- a/.github/workflows/nightly-ubuntu.yml
+++ b/.github/workflows/nightly-ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
           ~/.cargo/bin/cargo-capi
           ~/.cargo/bin/cargo-cbuild
           ~/.cargo/bin/cargo-cinstall
-        key: linux-cargo-c-toolchain
+        key: linux-cargo-c-toolchain-1
 
     - name: Setup Environment
       run: |

--- a/.github/workflows/nightly-ubuntu.yml
+++ b/.github/workflows/nightly-ubuntu.yml
@@ -69,6 +69,7 @@ jobs:
     name: Deploy Nightly Build
     runs-on: ubuntu-latest
     needs: build
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
        

--- a/.github/workflows/nightly-win.yml
+++ b/.github/workflows/nightly-win.yml
@@ -278,6 +278,7 @@ jobs:
     name: Deploy Nightly Build
     runs-on: ubuntu-latest
     needs: [build_gui_x64, build_gui_arm64]
+    if: github.event_name != 'pull_request'
     steps:
       - uses: actions/checkout@v4
        

--- a/.github/workflows/nightly-win.yml
+++ b/.github/workflows/nightly-win.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
 
 env:
-  TOOLCHAIN_VERSION: "20250417"
-  TOOLCHAIN_SHA: "a93eb5db7d87985ddf812623b4403953a85be0ef"
-  TOOLCHAIN_FILE: "llvm-mingw-20250417-msvcrt-ubuntu-22.04-x86_64.tar.xz"
+  TOOLCHAIN_VERSION: "20250826"
+  TOOLCHAIN_SHA: "e89251ff7ee45fc45d50ed5c68ff45ebf77f0c83c8329db687d6c78652686738"
+  TOOLCHAIN_FILE: "llvm-mingw-20250826-msvcrt-ubuntu-22.04-x86_64.tar.xz"
 
 jobs:
   build_mingw_arm:

--- a/patches/0007-remove-fix-tune-ssim.patch
+++ b/patches/0007-remove-fix-tune-ssim.patch
@@ -1,0 +1,255 @@
+diff --git a/contrib/svt-av1/A02-Fix-tune-ssim.patch b/contrib/svt-av1/A02-Fix-tune-ssim.patch
+deleted file mode 100644
+index 40dc79e5e..000000000
+--- a/contrib/svt-av1/A02-Fix-tune-ssim.patch
++++ /dev/null
+@@ -1,249 +0,0 @@
+-From 0f3bbd270efc743ed8fe73de33479f95d7bb8616 Mon Sep 17 00:00:00 2001
+-From: hguermaz <hassen.guermazi@intel.com>
+-Date: Sat, 16 Aug 2025 08:45:57 +0200
+-Subject: [PATCH] Fix --tune ssim
+-
+----
+- Source/API/EbDebugMacros.h             |  1 +
+- Source/Lib/Codec/md_process.c          | 21 ++++++++-
+- Source/Lib/Codec/md_process.h          |  6 +++
+- Source/Lib/Codec/product_coding_loop.c | 59 +++++++++++++++++++++++---
+- 4 files changed, 80 insertions(+), 7 deletions(-)
+-
+-diff --git a/Source/API/EbDebugMacros.h b/Source/API/EbDebugMacros.h
+-index 168ee5a3..83cf535d 100644
+---- a/Source/API/EbDebugMacros.h
+-+++ b/Source/API/EbDebugMacros.h
+-@@ -34,6 +34,7 @@
+- extern "C" {
+- #endif // __cplusplus
+- 
+-+#define FIX_TUNE_SSIM               1 // Fix SSIM mode
+- //FOR DEBUGGING - Do not remove
+- #define OPT_LD_LATENCY2         1 // Latency optimization for low delay - to keep the Macro for backwards testing until 3.0
+- #define LOG_ENC_DONE            0 // log encoder job one
+-diff --git a/Source/Lib/Codec/md_process.c b/Source/Lib/Codec/md_process.c
+-index aaa8abdd..772b28a3 100644
+---- a/Source/Lib/Codec/md_process.c
+-+++ b/Source/Lib/Codec/md_process.c
+-@@ -103,9 +103,17 @@ static void mode_decision_context_dctor(EbPtr p) {
+-     EB_FREE_ARRAY(obj->mdc_sb_array.split_flag);
+-     EB_FREE_ARRAY(obj->mdc_sb_array.refined_split_flag);
+-     EB_FREE_ARRAY(obj->mdc_sb_array.consider_block);
+-+#if FIX_TUNE_SSIM
+-+    for (uint32_t txt_itr = 0; txt_itr < TX_TYPES; ++txt_itr) {
+-+        EB_DELETE(obj->recon_coeff_ptr[txt_itr]);
+-+        EB_DELETE(obj->recon_ptr[txt_itr]);
+-+        EB_DELETE(obj->quant_coeff_ptr[txt_itr]);
+-+    }
+-+#else
+-     EB_DELETE(obj->tx_search_recon_coeff_ptr);
+-     EB_DELETE(obj->tx_search_recon_ptr);
+-     EB_DELETE(obj->tx_search_quant_coeff_ptr);
+-+#endif
+-     EB_DELETE(obj->tx_coeffs);
+-     EB_DELETE(obj->scratch_prediction_ptr);
+-     EB_DELETE(obj->temp_residual);
+-@@ -415,7 +423,17 @@ EbErrorType svt_aom_mode_decision_context_ctor(ModeDecisionContext *ctx, Sequenc
+-     thirty_two_width_picture_buffer_desc_init_data.top_padding        = 0;
+-     thirty_two_width_picture_buffer_desc_init_data.bot_padding        = 0;
+-     thirty_two_width_picture_buffer_desc_init_data.split_mode         = false;
+--
+-+#if FIX_TUNE_SSIM
+-+    for (uint32_t txt_itr = 0; txt_itr < TX_TYPES; ++txt_itr) {
+-+        EB_NEW(ctx->recon_coeff_ptr[txt_itr],
+-+               svt_picture_buffer_desc_ctor,
+-+               (EbPtr)&thirty_two_width_picture_buffer_desc_init_data);
+-+        EB_NEW(ctx->recon_ptr[txt_itr], svt_picture_buffer_desc_ctor, (EbPtr)&picture_buffer_desc_init_data);
+-+        EB_NEW(ctx->quant_coeff_ptr[txt_itr],
+-+               svt_picture_buffer_desc_ctor,
+-+               (EbPtr)&thirty_two_width_picture_buffer_desc_init_data);
+-+    }
+-+#else
+-     // Allocate temporary buffers used in TXT search
+-     EB_NEW(ctx->tx_search_recon_coeff_ptr,
+-            svt_picture_buffer_desc_ctor,
+-@@ -424,6 +442,7 @@ EbErrorType svt_aom_mode_decision_context_ctor(ModeDecisionContext *ctx, Sequenc
+-     EB_NEW(ctx->tx_search_quant_coeff_ptr,
+-            svt_picture_buffer_desc_ctor,
+-            (EbPtr)&thirty_two_width_picture_buffer_desc_init_data);
+-+#endif
+-     EB_NEW(ctx->tx_coeffs, svt_picture_buffer_desc_ctor, (EbPtr)&thirty_two_width_picture_buffer_desc_init_data);
+-     EB_NEW(ctx->scratch_prediction_ptr, svt_picture_buffer_desc_ctor, (EbPtr)&picture_buffer_desc_init_data);
+-     EbPictureBufferDescInitData double_width_picture_buffer_desc_init_data;
+-diff --git a/Source/Lib/Codec/md_process.h b/Source/Lib/Codec/md_process.h
+-index 1ec40295..2cd1d78a 100644
+---- a/Source/Lib/Codec/md_process.h
+-+++ b/Source/Lib/Codec/md_process.h
+-@@ -1069,10 +1069,16 @@ typedef struct ModeDecisionContext {
+-     uint8_t             params_status; // specifies the status of MD parameters; 0: default, 1: modified
+-     NsqPsqTxsCtrls      nsq_psq_txs_ctrls;
+-     uint8_t             sb_size;
+-+#if FIX_TUNE_SSIM
+-+    EbPictureBufferDesc *recon_coeff_ptr[TX_TYPES];
+-+    EbPictureBufferDesc *recon_ptr[TX_TYPES];
+-+    EbPictureBufferDesc *quant_coeff_ptr[TX_TYPES];
+-+#else
+-     // Temp buffers to store results during TXT search
+-     EbPictureBufferDesc *tx_search_recon_coeff_ptr;
+-     EbPictureBufferDesc *tx_search_recon_ptr;
+-     EbPictureBufferDesc *tx_search_quant_coeff_ptr;
+-+#endif
+-     // buffer used to store transformed coeffs during TX/Q/IQ. TX'd coeffs are only needed
+-     // temporarily, so no need to save for each TX type.
+-     EbPictureBufferDesc *tx_coeffs;
+-diff --git a/Source/Lib/Codec/product_coding_loop.c b/Source/Lib/Codec/product_coding_loop.c
+-index a4f592e1..10e91890 100644
+---- a/Source/Lib/Codec/product_coding_loop.c
+-+++ b/Source/Lib/Codec/product_coding_loop.c
+-@@ -4023,30 +4023,51 @@ static void tx_reset_neighbor_arrays(PictureControlSet *pcs, ModeDecisionContext
+-                                NEIGHBOR_ARRAY_UNIT_TOP_AND_LEFT_ONLY_MASK);
+-     }
+- }
+-+#if FIX_TUNE_SSIM
+-+static void copy_txt_data(ModeDecisionCandidateBuffer *cand_bf, ModeDecisionContext *ctx, uint32_t txb_origin_index,
+-+                          TxType best_tx_type) {
+-+#else
+- static void copy_txt_data(ModeDecisionCandidateBuffer *cand_bf, ModeDecisionContext *ctx, uint32_t txb_origin_index) {
+-+#endif
+-     uint8_t  tx_depth      = ctx->tx_depth;
+-     uint32_t txb_1d_offset = ctx->txb_1d_offset;
+-     uint8_t  tx_width      = ctx->blk_geom->tx_width[tx_depth];
+-     uint8_t  tx_height     = ctx->blk_geom->tx_height[tx_depth];
+-     // copy recon_coeff_ptr
+-     memcpy(((int32_t *)cand_bf->rec_coeff->buffer_y) + txb_1d_offset,
+-+#if FIX_TUNE_SSIM
+-+           ((int32_t *)ctx->recon_coeff_ptr[best_tx_type]->buffer_y) + txb_1d_offset,
+-+#else
+-            ((int32_t *)ctx->tx_search_recon_coeff_ptr->buffer_y) + txb_1d_offset,
+-+#endif
+-            (tx_width * tx_height * sizeof(uint32_t)));
+-     // copy quant_coeff_ptr
+-     memcpy(((int32_t *)cand_bf->quant->buffer_y) + txb_1d_offset,
+-+#if FIX_TUNE_SSIM
+-+           ((int32_t *)ctx->quant_coeff_ptr[best_tx_type]->buffer_y) + txb_1d_offset,
+-+#else
+-            ((int32_t *)ctx->tx_search_quant_coeff_ptr->buffer_y) + txb_1d_offset,
+-+#endif
+-            (tx_width * tx_height * sizeof(uint32_t)));
+-     // copy recon_ptr
+-     EbPictureBufferDesc *recon_ptr = cand_bf->recon;
+-     if (ctx->hbd_md) {
+-         for (uint32_t j = 0; j < tx_height; ++j)
+-             memcpy(((uint16_t *)recon_ptr->buffer_y) + txb_origin_index + j * recon_ptr->stride_y,
+-+#if FIX_TUNE_SSIM
+-+                   ((uint16_t *)ctx->recon_ptr[best_tx_type]->buffer_y) + txb_origin_index + j * recon_ptr->stride_y,
+-+#else
+-                    ((uint16_t *)ctx->tx_search_recon_ptr->buffer_y) + txb_origin_index + j * recon_ptr->stride_y,
+-+#endif
+-                    tx_width * sizeof(uint16_t));
+-     } else {
+-         for (uint32_t j = 0; j < tx_height; ++j)
+-             memcpy(recon_ptr->buffer_y + txb_origin_index + j * recon_ptr->stride_y,
+-+#if FIX_TUNE_SSIM
+-+                   ctx->recon_ptr[best_tx_type]->buffer_y + txb_origin_index + j * recon_ptr->stride_y,
+-+#else
+-                    ctx->tx_search_recon_ptr->buffer_y + txb_origin_index + j * recon_ptr->stride_y,
+-+#endif
+-                    ctx->blk_geom->tx_width[tx_depth]);
+-     }
+- }
+-@@ -4313,11 +4334,13 @@ static void tx_type_search(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
+-                             &ctx->luma_txb_skip_context,
+-                             &ctx->luma_dc_sign_context);
+-     TxType best_tx_type = DCT_DCT;
+-+#if !FIX_TUNE_SSIM
+-     // buffer is 0 or 1 to alternate between using cand_bf buffers and temporary buffers.
+-     // Data is stored for the best-so-far-TX data and the currently-being-searched TX type data. After the
+-     // search, the cand_bf data will be updated with the best.
+-     uint8_t txt_buffer      = 0;
+-     uint8_t best_txt_buffer = 0;
+-+#endif
+-     // local variables for all TX types
+-     uint16_t        eob_txt[TX_TYPES]                                              = {0};
+-     uint8_t         quantized_dc_txt[TX_TYPES]                                     = {0};
+-@@ -4359,11 +4382,19 @@ static void tx_type_search(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
+-                 }
+-             }
+-             // Do not use temporary buffers when TXT is OFF
+-+#if FIX_TUNE_SSIM
+-+            EbPictureBufferDesc *recon_coeff_ptr = (tx_type == DCT_DCT) ? cand_bf->rec_coeff
+-+                                                                        : ctx->recon_coeff_ptr[tx_type];
+-+            EbPictureBufferDesc *recon_ptr       = (tx_type == DCT_DCT) ? cand_bf->recon : ctx->recon_ptr[tx_type];
+-+            EbPictureBufferDesc *quant_coeff_ptr = (tx_type == DCT_DCT) ? cand_bf->quant
+-+                                                                        : ctx->quant_coeff_ptr[tx_type];
+-+#else
+-             assert(IMPLIES(tx_type == DCT_DCT, txt_buffer == 0));
+-             EbPictureBufferDesc *recon_coeff_ptr = txt_buffer ? ctx->tx_search_recon_coeff_ptr : cand_bf->rec_coeff;
+-             EbPictureBufferDesc *recon_ptr       = txt_buffer ? ctx->tx_search_recon_ptr : cand_bf->recon;
+-             EbPictureBufferDesc *quant_coeff_ptr = txt_buffer ? ctx->tx_search_quant_coeff_ptr : cand_bf->quant;
+--            ctx->three_quad_energy               = 0;
+-+#endif
+-+            ctx->three_quad_energy = 0;
+-             if (!tx_search_skip_flag) {
+-                 // Y: T Q i_q
+-                 svt_aom_estimate_transform(pcs,
+-@@ -4546,8 +4577,10 @@ static void tx_type_search(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
+-                 best_cost_tx_search = cost;
+-                 best_tx_type        = tx_type;
+-                 best_tx_non_coeff   = eob_txt[tx_type];
+--                best_txt_buffer     = txt_buffer;
+--                txt_buffer          = !txt_buffer;
+-+#if !FIX_TUNE_SSIM
+-+                best_txt_buffer = txt_buffer;
+-+                txt_buffer      = !txt_buffer;
+-+#endif
+-                 if (tx_type == DCT_DCT)
+-                     dct_dct_cost = cost;
+-             }
+-@@ -4581,8 +4614,11 @@ static void tx_type_search(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
+-             if (ssd_cost > ssd_cost_threshold) {
+-                 continue;
+-             }
+--
+-+#if FIX_TUNE_SSIM
+-+            EbPictureBufferDesc *recon_ptr = (tx_type == DCT_DCT) ? cand_bf->recon : ctx->recon_ptr[tx_type];
+-+#else
+-             EbPictureBufferDesc *recon_ptr = best_txt_buffer ? ctx->tx_search_recon_ptr : cand_bf->recon;
+-+#endif
+- 
+-             txb_full_distortion_txt[DIST_SSIM][tx_type][DIST_CALC_RESIDUAL] = svt_spatial_full_distortion_ssim_kernel(
+-                 input_pic->buffer_y,
+-@@ -4625,8 +4661,12 @@ static void tx_type_search(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
+-     // update with best_tx_type data
+-     (*y_coeff_bits) += y_txb_coeff_bits_txt[best_tx_type];
+-     if (ssim_level == SSIM_LVL_1) {
+--        EbPictureBufferDesc *recon_ptr          = best_txt_buffer ? ctx->tx_search_recon_ptr : cand_bf->recon;
+--        uint64_t             ssim_pred_dist     = svt_spatial_full_distortion_ssim_kernel(input_pic->buffer_y,
+-+#if FIX_TUNE_SSIM
+-+        EbPictureBufferDesc *recon_ptr = (best_tx_type == DCT_DCT) ? cand_bf->recon : ctx->recon_ptr[best_tx_type];
+-+#else
+-+        EbPictureBufferDesc *recon_ptr = best_txt_buffer ? ctx->tx_search_recon_ptr : cand_bf->recon;
+-+#endif
+-+        uint64_t ssim_pred_dist     = svt_spatial_full_distortion_ssim_kernel(input_pic->buffer_y,
+-                                                                           input_txb_origin_index,
+-                                                                           input_pic->stride_y,
+-                                                                           cand_bf->pred->buffer_y,
+-@@ -4677,12 +4717,19 @@ static void tx_type_search(PictureControlSet *pcs, ModeDecisionContext *ctx, Mod
+-     cand_bf->quant_dc.y[ctx->txb_itr] = quantized_dc_txt[best_tx_type];
+-     cand_bf->eob.y[ctx->txb_itr]      = eob_txt[best_tx_type];
+-     // Do not copy when the best TXT data is already in cand_bf
+-+#if FIX_TUNE_SSIM
+-+    if (best_tx_type != DCT_DCT) {
+-+        // copy best_tx_type data
+-+        copy_txt_data(cand_bf, ctx, txb_origin_index, best_tx_type);
+-+    }
+-+#else
+-     if (best_txt_buffer) {
+-         // txt_buffer is the buffer to be used for searching the next TX type (if applicable),
+-         // so its value should not be the same as the best. This check is a sanity check.
+-         assert(txt_buffer == 0);
+-         copy_txt_data(cand_bf, ctx, txb_origin_index);
+-     }
+-+#endif
+-     ctx->txb_1d_offset += ctx->blk_geom->tx_width[ctx->tx_depth] *
+-         (ctx->blk_geom->tx_height[ctx->tx_depth] >> ctx->mds_subres_step);
+-     // For Inter blocks, transform type of chroma follows luma transfrom type
+--- 
+-2.39.5 (Apple Git-154)
+-


### PR DESCRIPTION
This PR has several commit
- Don't deploy the nightly build if its a PR workflow run
- Invalidate cache to fix libdovi error
    - This fixes the build failure because of libdovi, not really a good fix but it works
- Remove fix tune ssim patch
    - This patch doesn't apply in v3.0.2, fixes build error
- Update dependencies
    - Update python in the nightly-mac workflow to 3.13.7
    - Update llvm-mingw in the windows workflow to 21.1.0
