### PR TITLE
Fix mac

### DIFF
--- a/.github/workflows/nightly-mac.yml
+++ b/.github/workflows/nightly-mac.yml
@@ -13,8 +13,8 @@ jobs:
     env:
       DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@v5
+    - uses: actions/setup-python@v6
       with:
         python-version: '3.13.7'
 
@@ -76,10 +76,10 @@ jobs:
     needs: build
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
        
       - name: Download Artifacts - Universal Binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: HandBrake-macos
           path: mac/


### PR DESCRIPTION
https://www.reddit.com/r/AV1/comments/1nul4nk/why_do_all_3_branches_of_svt_av1_crash/
https://www.reddit.com/r/handbrake/comments/1o3rjfw/cant_install_any_forked_versions_on_mac_mini_m4/

At some point LTO broke mac builds
It's been a month since mac builds are broken
Disabling LTO was confirmed to fix mac builds by juliobbv
Interestingly enough, the crash logs from HandBrake shows HandBrake failing to parse a json and doesn't indicate anything remotely close about LTO at all

Bump actions commit is a bonus and not related to the mac fix