### PR TITLE
Fix intra period length and leave it to the encoder

### DIFF
--- a/patches/0008-fix-hardcoded-10sec-gop.patch
+++ b/patches/0008-fix-hardcoded-10sec-gop.patch
@@ -1,0 +1,13 @@
+diff --git a/libhb/encsvtav1.c b/libhb/encsvtav1.c
+index 54f52a117..4e83bf751 100644
+--- a/libhb/encsvtav1.c
++++ b/libhb/encsvtav1.c
+@@ -206,7 +206,7 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
+         param->fast_decode = 0;
+     }
+ 
+-    param->intra_period_length = ((double)job->orig_vrate.num / job->orig_vrate.den + 0.5) * 10;
++    param->intra_period_length = -2;
+     // VFR isn't supported, the rate control will ignore
+     // the frames timestamps and use the values below
+     param->frame_rate_numerator = job->orig_vrate.num;


### PR DESCRIPTION
Currently, HandBrake sets 10 seconds keyint that differs from the encoder calculated keyint:
https://github.com/HandBrake/HandBrake/blob/master/libhb/encsvtav1.c#L209

This calculation isn't optimized to the encoder mini-gop.

For example, if the video is 60 fps:
HandBrake keyint = (60 + 0.5) x 100 = 605
Assume that the mini gop size is 32
605/32 = 18.90625

Meanwhile, for svt-av1-psyex, let's assume that mini gop size is 32
The formula is `((int)((fps + mini_gop_size) / mini_gop_size)*(mini_gop_size))` (from [here](https://github.com/BlueSwordM/svt-av1-psyex/blob/master/Source/Lib/Globals/enc_handle.c#L2473))

svt-av1-psyex keyint = ((int)((60 + 32) / 32) * (32)) = 64
Multiplied by 10 is 640
640/32 = 20

So HandBrake's keyint cuts the final mini-gop early

Ideally, svt-av1-psyex should adopt svt-av1-hdr's [approach](https://github.com/juliobbv-p/svt-av1-hdr/blob/main/Source/Lib/Globals/enc_handle.c#L2453) because 10 seconds keyint for 60 fps video is too large, even more for higher fps content (such as video game recordings).